### PR TITLE
Systemd 258 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,7 @@ streamcontroller official plugin to do OS Related actions
 Hotkeys and write text actions require you are in the input group and you have the following udev rule
 
 1. Add the udev rule
+    ```bash
+    sudo sh -c "echo 'ACTION!=\"remove\", KERNEL==\"uinput\", SUBSYSTEM==\"misc\", OPTIONS+=\"static_node=uinput\", TAG+=\"uaccess\", GROUP=\"input\", MODE=\"0660\"' > /etc/udev/rules.d/99-streamdeck-osplugin.rules"
     ```
-    sudo sh -c "echo 'KERNEL==\"uinput\", SUBSYSTEM==\"misc\", OPTIONS+=\"static_node=uinput\", TAG+=\"uaccess\", GROUP=\"input\", MODE=\"0660\"' > /etc/udev/rules.d/99-streamdeck-osplugin.rules"
-    ```
-2. Create the input Group (if not already present):
-    ```sh
-    sudo groupadd input
-    ```
-3. Add yourself to the `input` group
-    ```sh
-    sudo usermod -aG input $USER
-    ```
-4. Restart your computer to apply the changes
+2. Restart your computer to apply the changes


### PR DESCRIPTION
Systemd 258 has introduced [breaking changes](https://github.com/systemd/systemd/blob/v258/NEWS#L22-L32):
  
>ACLs for device nodes requested by "uaccess" udev tag are now always
          applied/updated by systemd-udevd through "uaccess" udev builtin, and
          systemd-logind no longer applies/updates ACLs but triggers "change"
          uevents to make systemd-udevd apply/update ACLs. Hence, the "uaccess"
          udev tag should be set not only on "add" action but also on "change"
          action, and it is highly recommended that the rule is applied all
          actions except for "remove" action.
          Recommended example:
          `ACTION!="remove", SUBSYSTEM=="hidraw", TAG+="uaccess"`
          The following example does not work since v258:
          `ACTION=="add", SUBSYSTEM=="hidraw", TAG+="uaccess"`

This PR adds the required `ACTION!="remove"` to the udev rule and also removes the instructions for creating the `input` group and adding an user to it, as this is [not needed](https://wiki.archlinux.org/title/Users_and_groups#Pre-systemd_groups) with systemd and udev.