### PR TITLE
Fix: Allow custom URL schemes in OpenInBrowser action

### DIFF
--- a/actions/OpenInBrowser/OpenInBrowser.py
+++ b/actions/OpenInBrowser/OpenInBrowser.py
@@ -6,6 +6,7 @@ from src.backend.PluginManager.PluginBase import PluginBase
 import os
 from PIL import Image
 import webbrowser
+from urllib.parse import urlparse
 
 # Import gtk modules
 import gi
@@ -60,7 +61,8 @@ class OpenInBrowser(ActionBase):
         if url in [None, ""]:
             return
         
-        if not url.startswith("http://") and not url.startswith("https://"):
+        # Allow any custom scheme, but default to https when no scheme is provided
+        if not urlparse(url).scheme:
             url = "https://" + url
 
         new = 1 if self.get_settings().get("new_window", False) else 0


### PR DESCRIPTION
Update `open_url` action to prepend `https://` only when the user did not specify any scheme, enabling custom protocols (obsidian://, slack://, etc.) to open unchanged.


Fix for https://github.com/StreamController/OSPlugin/issues/40

