### PR TITLE
Fix RunCommand Action Failing After Page Changes

### DIFF
--- a/actions/RunCommand/RunCommand.py
+++ b/actions/RunCommand/RunCommand.py
@@ -26,6 +26,8 @@ class RunCommand(ActionBase):
     def on_ready(self):
         self.set_media(media_path=os.path.join(self.plugin_base.PATH, "assets", "terminal.png"))
         self.start_timer()
+        # Reset registered_down flag to prevent action from being blocked after page changes
+        self.registered_down = False
 
     def stop_timer(self):
         if self.auto_run_timer is not None:


### PR DESCRIPTION
Resolves: https://github.com/StreamController/StreamController/issues/475

## Summary
Fixes a bug where the "Run Command" action stops working after the first button press when used together with "Change Page" actions on the same button.

## Bug Description
When a button has both "Change Page" and "Run Command" actions:
- **First press**: Both actions execute correctly
- **Subsequent presses**: Only "Change Page" executes, "Run Command" fails

### Root Cause
The RunCommand action has a `registered_down` flag (line 24) used as a workaround to prevent duplicate execution. However, this flag wasn't being reset when the page changed, causing subsequent executions to be blocked.

**Sequence of events:**
1. First button press: `registered_down` becomes `True`, then resets to `False` on key up ✅
2. Change Page action executes and switches pages
3. Second button press: `registered_down` is still `True` from previous page, action returns early ❌

## Solution
Reset the `registered_down` flag in the `on_ready()` method, which is called when actions are re-initialized after page changes.

### Changes Made
```python
def on_ready(self):
    self.set_media(media_path=os.path.join(self.plugin_base.PATH, "assets", "terminal.png"))
    self.start_timer()
    # Reset registered_down flag to prevent action from being blocked after page changes
    self.registered_down = False
```

**File:** `actions/RunCommand/RunCommand.py`  
**Line:** 30 (added)

## Why This Works
- When `DeckController.load_page()` is called, it executes `active_page.initialize_actions()`
- This calls `on_ready()` for all actions on the new page
- By resetting `registered_down = False` in `on_ready()`, the action can execute properly after page changes

## Testing
Created and verified with test script that demonstrates:
- **Before fix**: Action fails on subsequent button presses after page changes
- **After fix**: Action executes consistently regardless of page changes

### Steps to Reproduce (Before Fix)
1. Create a button with "Change Page" → "Default" and "Run Command" → `/tmp/test.sh`
2. Press button (works: page changes + command runs)
3. Go back to original page
4. Press button again (fails: only page changes, command doesn't run)

### Expected Behavior (After Fix)
Both actions execute consistently on every button press.

## Impact
- **Fixes**: RunCommand action reliability when used with page navigation
- **Breaking Changes**: None
- **Performance**: No impact (minimal flag reset operation)

## Related Issues
- Temporary workaround mentioned in line 24 comment
- Affects any combination of RunCommand + ChangePage actions on same button

## Files Changed
- `actions/RunCommand/RunCommand.py` (1 line added)

## Testing Commands
```bash
# Create test script
echo '#!/bin/bash
echo "$(date): RunCommand test" >> /tmp/runcommand-test.log' > /tmp/test.sh
chmod +x /tmp/test.sh

# Test the fix by pressing button multiple times
# Check log: cat /tmp/runcommand-test.log
```
