### PR TITLE
Fix auto-run timer stopping unexpectedly

### DIFF
--- a/actions/RunCommand/RunCommand.py
+++ b/actions/RunCommand/RunCommand.py
@@ -60,7 +60,7 @@ class RunCommand(ActionBase):
                 if self.auto_run_timer is not None:
                     self.stop_timer()
             elif event == Input.Key.Events.SHORT_UP:
-                self.execute()
+                self.execute(restart_timer=self.get_settings().get("auto_run", 0) > 0)
 
     def execute(self, restart_timer: bool = False):
         self.stop_timer()

--- a/actions/RunCommand/RunCommand.py
+++ b/actions/RunCommand/RunCommand.py
@@ -71,7 +71,7 @@ class RunCommand(ActionBase):
             self.set_center_label(result)
 
         if restart_timer:
-            if self.get_is_present() and not settings.get("keep_auto_run_in_background", False): #TODO: Find a better solution
+            if self.get_is_present() or settings.get("keep_auto_run_in_background", False):
                 self.start_timer()
 
     def get_config_rows(self):


### PR DESCRIPTION
This PR fixes two issues with the "Run Command" action.

First, the timer was previously only being restarted when the action was present on the active page *and* "Keep auto running in background" was disabled. As a result, enabling "Keep auto running in background" caused the command to execute only once. Changing this condition from `and not` to `or` allows the timer to continue running when background execution is enabled.

Second, manually executing the command would stop the active timer without restarting it, preventing any future automatic executions. Restarting the timer after a manual execution ensures that auto-run continues to function and that the interval is reset from the time of the button press.